### PR TITLE
Missing some rawurlencode

### DIFF
--- a/class.contextio.php
+++ b/class.contextio.php
@@ -547,7 +547,7 @@ class ContextIO {
 				throw new InvalidArgumentException("params array contains invalid parameters or misses required parameters");
 			}
 		}
-		return $this->get($user, 'email_accounts/' . $params['label']);
+		return $this->get($user, 'email_accounts/' . rawurlencode($params['label']));
 	}
 
 	/**
@@ -603,7 +603,7 @@ class ContextIO {
 		}
 		$email_account = $params['label'];
 		unset($params['label']);
-		return $this->get($user, 'email_accounts/' . $email_account . '/folders', $params);
+		return $this->get($user, 'email_accounts/' . rawurlencode($email_account) . '/folders', $params);
 	}
 
 	public function getEmailAccountFolder($user, $params=array()) {
@@ -637,7 +637,7 @@ class ContextIO {
 				throw new InvalidArgumentException("params array contains invalid parameters or misses required parameters");
 			}
 		}
-		return $this->get($user, 'webhooks/' . $params['webhook_id']);
+		return $this->get($user, 'webhooks/' . rawurlencode($params['webhook_id']));
 	}
 
 	public function addWebhook($user, $params) {


### PR DESCRIPTION
Some more params were missing rawurlencode, so a label with slashes didn't work when calling 'listMessages'.