### PR TITLE
Add support for provider_refresh_token in addUser method.

### DIFF
--- a/class.contextio.php
+++ b/class.contextio.php
@@ -468,7 +468,7 @@ class ContextIO {
 	}
 
 	public function addUser($params) {
-		$params = $this->_filterParams($params, array('email','first_name','last_name','type','server','username','provider_consumer_key','provider_token','provider_token_secret','service_level','password','use_ssl','port','raw_file_list','expunge_on_deleted_flag', 'migrate_account_id'), array('email'));
+		$params = $this->_filterParams($params, array('email','first_name','last_name','type','server','username','provider_consumer_key','provider_token','provider_token_secret','provider_refresh_token','service_level','password','use_ssl','port','raw_file_list','expunge_on_deleted_flag', 'migrate_account_id'), array('email'));
 		if ($params === false) {
 			throw new InvalidArgumentException("params array contains invalid parameters or misses required parameters");
 		}


### PR DESCRIPTION
addUser method will always fail for Oauth providers if provider_refresh_token is not supplied. 

This adds support for provider_refresh_token to be sent when adding a user.