### PR TITLE
Remove unsupported params from addUser

### DIFF
--- a/class.contextio.php
+++ b/class.contextio.php
@@ -468,7 +468,7 @@ class ContextIO {
 	}
 
 	public function addUser($params) {
-		$params = $this->_filterParams($params, array('email','first_name','last_name','type','server','username','provider_consumer_key','provider_token','provider_token_secret','provider_refresh_token','service_level','password','use_ssl','port','raw_file_list','expunge_on_deleted_flag', 'migrate_account_id'), array('email'));
+		$params = $this->_filterParams($params, array('email','first_name','last_name','type','server','username','provider_consumer_key','provider_refresh_token','password','use_ssl','port','migrate_account_id'), array('email'));
 		if ($params === false) {
 			throw new InvalidArgumentException("params array contains invalid parameters or misses required parameters");
 		}


### PR DESCRIPTION
Removing the following unsupported params `'provider_token','provider_token_secret','service_level','raw_file_list', and 'expunge_on_deleted_flag'`.