### PR TITLE
status_callback_url not present in addUser or modifyEmailAccount

### DIFF
--- a/class.contextio.php
+++ b/class.contextio.php
@@ -468,7 +468,7 @@ class ContextIO {
 	}
 
 	public function addUser($params) {
-		$params = $this->_filterParams($params, array('email','first_name','last_name','type','server','username','provider_consumer_key','provider_token','provider_token_secret','provider_refresh_token','service_level','password','use_ssl','port','raw_file_list','expunge_on_deleted_flag', 'migrate_account_id'), array('email'));
+		$params = $this->_filterParams($params, array('email','first_name','last_name','type','server','username','provider_consumer_key','provider_token','provider_token_secret','provider_refresh_token','service_level','password','use_ssl','port','raw_file_list','expunge_on_deleted_flag', 'migrate_account_id', 'status_callback_url'), array('email'));
 		if ($params === false) {
 			throw new InvalidArgumentException("params array contains invalid parameters or misses required parameters");
 		}
@@ -519,7 +519,7 @@ class ContextIO {
 		if (is_null($user) || ! is_string($user) || (! strpos($user, '@') === false)) {
 			throw new InvalidArgumentException('user must be string representing userId');
 		}
-		$params = $this->_filterParams($params, array('provider_token', 'provider_token_secret', 'provider_refresh_token', 'password', 'provider_consumer_key', 'status', 'force_status_check'), array('label'));
+		$params = $this->_filterParams($params, array('provider_token', 'provider_token_secret', 'provider_refresh_token', 'password', 'provider_consumer_key', 'status', 'force_status_check', 'status_callback_url'), array('label'));
 		if ($params === false) {
 			throw new InvalidArgumentException("params array contains invalid parameters or misses required parameters");
 		}


### PR DESCRIPTION
Allow status_callback_url to be set in addUser and modifyEmailAccount as per documentation.

https://context.io/docs/lite/users/email_accounts
https://context.io/docs/lite/users